### PR TITLE
Enable shared tiles and villager-created farms

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,13 +5,12 @@ Mini Colony Simulator is a lightweight browser game that depicts a small communi
 ## Game Mechanics
 
 - The world is a grid of grass and farmland tiles.
-- Farmland tiles may appear on empty grass and have a small chance each tick to regrow crops after being harvested. Grown crops show a random food emoji.
-- Villagers search for farmland with crops, harvest a single unit of food, then carry it back to the nearest house.
-- Harvested farmland turns back into grass.
+- Villagers convert grass tiles into farmland as they walk over them. Farmland has a small chance each tick to regrow crops after being harvested. Grown crops show a random food emoji.
+- Villagers search for farmland with crops, harvest a single unit of food, then carry it back to the nearest house. Harvested farmland remains farmland.
 - Houses store deposited food. Each house provides housing for five villagers.
 - When the population has reached the current housing capacity and at least 20 food is available, a villager on a grass tile will build a new house.
 - Houses with stored food periodically spend one food to spawn an additional villager if housing space is available. Villagers are represented by a variety of sports-themed emojis.
-- Villagers slowly lose hunger and age over time. They eat stored food when hungry and die if their hunger runs out or they surpass their lifespan. Villagers can no longer occupy the same grid space.
+- Villagers slowly lose hunger and age over time. They eat stored food when hungry and die if their hunger runs out or they surpass their lifespan. Villagers can share the same grid space.
 - Hovering over a villager or house reveals a tooltip with its name and status.
 - Food, population and house counts are shown beneath the canvas and update continuously.
 

--- a/script.js
+++ b/script.js
@@ -75,7 +75,7 @@ function getHousingCapacity() {
 }
 
 function isTileOccupied(x, y, ignore) {
-    return villagers.some(v => v !== ignore && v.x === x && v.y === y);
+    return false;
 }
 
 function findNearestHouse(x, y, requireFood = false) {
@@ -159,11 +159,10 @@ const tiles = [];
 for (let y = 0; y < GRID_HEIGHT; y++) {
     tiles[y] = [];
     for (let x = 0; x < GRID_WIDTH; x++) {
-        const type = Math.random() < 0.1 ? 'farmland' : 'grass';
         tiles[y][x] = {
-            type,
-            hasCrop: type === 'farmland',
-            cropEmoji: type === 'farmland' ? FOOD_EMOJIS[Math.floor(Math.random() * FOOD_EMOJIS.length)] : null,
+            type: 'grass',
+            hasCrop: false,
+            cropEmoji: null,
             stored: 0,
             name: null
         };
@@ -277,6 +276,13 @@ function stepVillager(v, index) {
         }
     }
 
+    // Convert grass to farmland when not carrying anything
+    if (!v.carrying && tile.type === 'grass') {
+        tile.type = 'farmland';
+        tile.hasCrop = false;
+        tile.cropEmoji = null;
+    }
+
     // Eat if hungry
     if (v.hunger < 50 || v.task === 'eat') {
         if (tile.type === 'house' && tile.stored > 0) {
@@ -317,7 +323,6 @@ function stepVillager(v, index) {
             if (targetTile.type === 'farmland' && targetTile.hasCrop) {
                 targetTile.hasCrop = false;
                 targetTile.cropEmoji = null;
-                targetTile.type = 'grass';
                 v.carrying = 1;
             }
             v.task = null;
@@ -340,18 +345,12 @@ let spawnTimer = 200;
 function gameTick() {
     if (!running) return;
 
-    // Grow food on farmland and occasionally convert grass to new farmland
+    // Grow food on farmland tiles
     for (let y = 0; y < GRID_HEIGHT; y++) {
         for (let x = 0; x < GRID_WIDTH; x++) {
             const t = tiles[y][x];
             if (t.type === 'farmland') {
-                if (!t.hasCrop && Math.random() < 0.05) {
-                    t.hasCrop = true;
-                    t.cropEmoji = FOOD_EMOJIS[Math.floor(Math.random() * FOOD_EMOJIS.length)];
-                }
-            } else if (t.type === 'grass') {
-                if (Math.random() < 0.001) {
-                    t.type = 'farmland';
+                if (!t.hasCrop && Math.random() < 0.02) {
                     t.hasCrop = true;
                     t.cropEmoji = FOOD_EMOJIS[Math.floor(Math.random() * FOOD_EMOJIS.length)];
                 }


### PR DESCRIPTION
## Summary
- allow multiple villagers on one tile
- remove random farmland spawning and slow crop growth a bit
- keep farmland after harvest and let villagers convert grass to farmland
- update README for the new rules

## Testing
- `npm test` *(fails: package.json missing)*
- `node --check script.js`