### PR TITLE
Improve world generation and logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@ Mini Colony Simulator is a lightweight browser game that depicts a small communi
 
 ## Game Mechanics
 
-- The world is procedurally generated with grass, water, forests, mountains and ore deposits. Grass and farmland tiles are drawn with darker colors.
-- Villagers convert grass tiles into farmland as they walk over them. Farmland has a small chance each tick to regrow crops after being harvested. Grown crops show a random food emoji.
-- The colony begins with only a single house; farmland must be created by villagers.
+- The world is procedurally generated with grass, water, forests, mountains and ore deposits using roaming walkers for more natural looking terrain. Grass and farmland tiles are drawn with darker colors. Forest tiles show a tree emoji.
+- Villagers convert grass tiles into farmland as they walk over them. The landscape starts without farmland. Farmland has a small chance each tick to regrow crops after being harvested. Grown crops show a random food emoji.
+- The colony begins with a single house placed at a random location and the first villager starts on that house. Farmland must be created by villagers.
 - Villagers search for farmland with crops, harvest a single unit of food, then carry it back to the nearest house. Harvested farmland remains farmland.
 - Houses store deposited food. Each house provides housing for five villagers and is given a procedurally generated name.
 - When the population has reached the current housing capacity and at least 20 food is available, a villager on a grass tile will build a new house.
@@ -15,7 +15,7 @@ Mini Colony Simulator is a lightweight browser game that depicts a small communi
 - Hovering over any tile shows a tooltip listing everything on that space. The
   tooltip updates continuously even when the mouse stays still.
 - Food, population and house counts are shown beneath the canvas and update continuously.
-- A scrolling log beneath the counts records notable events with the most recent entry at the top.
+- A scrolling log beneath the counts records notable events with the most recent entry at the top. Log entries include timestamps and omit food harvest and deposit messages.
 
 ## How to Play
 


### PR DESCRIPTION
## Summary
- create random-walk terrain generation and drop farmland patches
- spawn starting house on a random grass tile with villager on top
- display tree emoji on forest tiles
- timestamp log entries
- stop logging food harvests and deposits
- update README with new mechanics

## Testing
- `npm test` *(fails: package.json missing)*