### PR TITLE
Update health and farmland logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,13 +5,13 @@ Mini Colony Simulator is a lightweight browser game that depicts a small communi
 ## Game Mechanics
 
 - The world is procedurally generated with grass, water, forests, mountains and ore deposits using roaming walkers for more natural looking terrain. Grass and farmland tiles are drawn with darker colors. Forest tiles show a tree emoji.
-- Villagers convert grass tiles into farmland as they walk over them. The landscape starts without farmland. Farmland has a small chance each tick to regrow crops after being harvested. Grown crops show a random food emoji.
+- Villagers create new farmland when stored food is low or there are too few fields for the population. Farmland has a small chance each tick to regrow crops after being harvested. Grown crops show a random food emoji.
 - The colony begins with a single house placed at a random location and the first villager starts on that house. Farmland must be created by villagers.
 - Villagers search for farmland with crops, harvest a single unit of food, then carry it back to the nearest house. Harvested farmland remains farmland.
 - Houses store deposited food. Each house provides housing for five villagers and is given a procedurally generated name.
 - When the population has reached the current housing capacity and at least 20 food is available, a villager on a grass tile will build a new house.
 - Houses with stored food periodically spend one food to spawn an additional villager if housing space is available. Villagers are represented by a variety of sports-themed emojis.
-- Villagers slowly lose hunger and age over time. They eat stored food when hungry and die if their hunger runs out or they surpass their lifespan. Villagers can share the same grid space.
+- Villagers slowly lose health and age over time. They eat stored food when low on health and die if it reaches zero or they surpass their lifespan. Dead villagers leave behind a skull or skeleton.
 - Hovering over any tile shows a tooltip listing everything on that space. The
   tooltip updates continuously even when the mouse stays still.
 - Food, population and house counts are shown beneath the canvas and update continuously.


### PR DESCRIPTION
## Summary
- rename `hunger` to `health`
- add corpse emojis and display corpses when villagers die
- make villagers create farmland when food is low or fields are sparse
- show corpses and health in tooltips
- document the new mechanics

## Testing
- `node -e "require('./script.js')"` *(fails: ReferenceError: document is not defined)*