### PR TITLE
Responsive map and new aging

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,12 +6,13 @@ Mini Colony Simulator is a lightweight browser game that depicts a small communi
 
 - The world is procedurally generated with grass, water, forests, mountains and ore deposits using roaming walkers for more natural looking terrain. Grass and farmland tiles are drawn with darker colors. Forest tiles show a tree emoji.
 - Villagers create new farmland when stored food is low or there are too few fields for the population. They will travel to the nearest grass tile and convert it into farmland. Farmland has a small chance each tick to regrow crops after being harvested. Grown crops show a random food emoji.
+- The game map scales to your browser, covering 95% of its width and 50% of its height when the world is generated.
 - The colony begins with a single house placed at a random location and the first villager starts on that house. Farmland must be created by villagers.
 - Villagers search for farmland with crops, harvest a single unit of food, then carry it back to the nearest house. Harvested farmland remains farmland.
 - Houses store deposited food. Each house provides housing for five villagers and is given a procedurally generated name.
 - When the population has reached the current housing capacity and at least 20 food is available, a villager on a grass tile will build a new house.
 - Houses with stored food periodically spend one food to spawn an additional villager if housing space is available. Villagers are represented by a variety of sports-themed emojis.
-- Villagers slowly lose health and age over time. They eat stored food when low on health and die if it reaches zero or they surpass their lifespan. Dead villagers leave behind a skull or skeleton.
+- Villagers slowly lose health and age over time. They eat stored food when low on health and have an increasing chance to die of old age each tick, from 0% at birth to 100% after 1000 ticks. Dead villagers leave behind a skull or skeleton.
 - Hovering over any tile shows a tooltip listing everything on that space. The
   tooltip updates continuously even when the mouse stays still.
 - Food, population and house counts are shown beneath the canvas and update continuously.

--- a/index.html
+++ b/index.html
@@ -8,7 +8,7 @@
 </head>
 <body>
     <h1>Mini Colony Simulator</h1>
-    <canvas id="gameCanvas" width="1200" height="592"></canvas>
+    <canvas id="gameCanvas"></canvas>
     <div id="tooltip" class="tooltip"></div>
     <div id="controls">
         <button id="toggleSim">Pause</button>

--- a/script.js
+++ b/script.js
@@ -1,5 +1,9 @@
 const canvas = document.getElementById('gameCanvas');
 const ctx = canvas.getContext('2d');
+
+// Size the canvas based on the current window dimensions
+canvas.width = Math.floor(window.innerWidth * 0.95);
+canvas.height = Math.floor(window.innerHeight * 0.5);
 const foodCountEl = document.getElementById('foodCount');
 const populationCountEl = document.getElementById('populationCount');
 const houseCountEl = document.getElementById('houseCount');
@@ -278,7 +282,6 @@ function addVillager(x, y) {
         status: 'idle',
         health: 100,
         age: 0,
-        lifespan: 2000 + Math.floor(Math.random() * 1000),
         name: generateName(),
         emoji: VILLAGER_EMOJIS[Math.floor(Math.random() * VILLAGER_EMOJIS.length)]
     });
@@ -344,7 +347,8 @@ function draw() {
 
 function stepVillager(v, index) {
     v.age++;
-    if (v.age >= v.lifespan) {
+    const deathChance = Math.min(1, v.age / 1000);
+    if (Math.random() < deathChance) {
         log(`${v.name} passed away of old age`);
         tiles[v.y][v.x].corpseEmoji = CORPSE_EMOJIS[Math.floor(Math.random() * CORPSE_EMOJIS.length)];
         villagers.splice(index, 1);
@@ -586,7 +590,7 @@ function updateTooltip() {
     const here = villagers.filter(v => v.x === hoverX && v.y === hoverY);
     for (const v of here) {
         lines.push(`<strong>${v.name}</strong> ${v.emoji}`,
-                   `Age: ${v.age}/${v.lifespan}`,
+                   `Age: ${v.age}`,
                    `Health: ${Math.floor(v.health)}`,
                    `Status: ${v.status}`);
     }


### PR DESCRIPTION
## Summary
- resize canvas to 95% of window width and 50% of height at start
- remove fixed villager lifespans and use increasing death chance
- adjust tooltip and README for new aging rules
- mention dynamic canvas sizing in README

## Testing
- `node --check script.js`
