### PR TITLE
Villagers wait by default and ignore collisions

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Mini Colony Simulator is a lightweight browser game that depicts a small communi
 - The game map scales to your browser, covering 95% of its width and 60% of its height when the world is generated.
 - The colony begins with a single house placed at a random location and the first villager starts on that house. Farmland must be created by villagers.
 - Villagers search for farmland with crops, harvest a single unit of food, then carry it back to the nearest house. Harvested farmland remains farmland.
+- When villagers have no immediate task they now wait in place instead of wandering randomly.
 - Houses store deposited food. Each house provides housing for five villagers and is given a procedurally generated name.
 - When the population has reached the current housing capacity and at least 20 food is available, a villager on a grass tile will build a new house.
 - Houses with stored food periodically spend one food to spawn an additional villager if housing space is available. Villagers are represented by a variety of sports-themed emojis.

--- a/src/villager.js
+++ b/src/villager.js
@@ -63,13 +63,9 @@ export function getHousingCapacity() {
     return houseCount * 5;
 }
 
-function isTileOccupied(x, y, ignore) {
+function isTileOccupied(x, y) {
     if (x < 0 || y < 0 || x >= GRID_WIDTH || y >= GRID_HEIGHT) return true;
     if (tiles[y][x].type === 'water') return true;
-    for (const v of villagers) {
-        if (v === ignore) continue;
-        if (v.x === x && v.y === y) return true;
-    }
     return false;
 }
 
@@ -133,7 +129,7 @@ function moveTowards(v, target) {
     else if (v.x > target.x) newX--;
     else if (v.y < target.y) newY++;
     else if (v.y > target.y) newY--;
-    if (!isTileOccupied(newX, newY, v)) {
+    if (!isTileOccupied(newX, newY)) {
         v.x = newX;
         v.y = newY;
     }
@@ -306,7 +302,7 @@ export function stepVillager(v, index, ticks, log) {
 
     if (!v.task) {
         v.target = findNearestCrop(v.x, v.y);
-        v.task = v.target ? 'gather' : 'wander';
+        v.task = v.target ? 'gather' : 'wait';
     }
 
     if (v.task === 'gather') {
@@ -326,13 +322,17 @@ export function stepVillager(v, index, ticks, log) {
             moveTowards(v, v.target);
         }
     } else {
-        const dir = Math.floor(Math.random() * 4);
-        if (dir === 0 && v.x > 0 && !isTileOccupied(v.x - 1, v.y, v)) v.x--;
-        if (dir === 1 && v.x < GRID_WIDTH - 1 && !isTileOccupied(v.x + 1, v.y, v)) v.x++;
-        if (dir === 2 && v.y > 0 && !isTileOccupied(v.x, v.y - 1, v)) v.y--;
-        if (dir === 3 && v.y < GRID_HEIGHT - 1 && !isTileOccupied(v.x, v.y + 1, v)) v.y++;
-        v.task = null;
-        status = 'wandering';
+        if (v.task === 'wait') {
+            status = 'waiting';
+        } else {
+            const dir = Math.floor(Math.random() * 4);
+            if (dir === 0 && v.x > 0 && !isTileOccupied(v.x - 1, v.y)) v.x--;
+            if (dir === 1 && v.x < GRID_WIDTH - 1 && !isTileOccupied(v.x + 1, v.y)) v.x++;
+            if (dir === 2 && v.y > 0 && !isTileOccupied(v.x, v.y - 1)) v.y--;
+            if (dir === 3 && v.y < GRID_HEIGHT - 1 && !isTileOccupied(v.x, v.y + 1)) v.y++;
+            v.task = null;
+            status = 'wandering';
+        }
     }
     v.status = status;
 }


### PR DESCRIPTION
## Summary
- let villagers share tiles by removing occupancy checks
- make idle villagers wait instead of wander
- document the new waiting behavior

## Testing
- `node --check src/villager.js`
- `node --check src/game.js`
