### PR TITLE
Adjust farmland ratio

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Mini Colony Simulator is a lightweight browser game that depicts a small communi
 ## Game Mechanics
 
 - The world is procedurally generated with grass, water, forests, mountains and ore deposits using roaming walkers for more natural looking terrain. Grass and farmland tiles are drawn with darker colors. Forest tiles show a tree emoji.
-- Villagers create new farmland when stored food is low or there are too few fields for the population. They will travel to the nearest grass tile and convert it into farmland. Farmland has a small chance each tick to regrow crops after being harvested. Grown crops show a random food emoji.
+- Villagers create new farmland when stored food is low or there are fewer than two fields per villager. They will travel to the nearest grass tile and convert it into farmland. Farmland has a small chance each tick to regrow crops after being harvested. Grown crops show a random food emoji.
 - The game map scales to your browser, covering 95% of its width and 60% of its height when the world is generated.
 - The colony begins with a single house placed at a random location and the first villager starts on that house. Farmland must be created by villagers.
 - Villagers search for farmland with crops, harvest a single unit of food, then carry it back to the nearest house. Harvested farmland remains farmland.

--- a/src/villager.js
+++ b/src/villager.js
@@ -3,6 +3,7 @@ import { tiles, GRID_WIDTH, GRID_HEIGHT, FOOD_EMOJIS, CORPSE_EMOJI } from './til
 export const villagers = [];
 export let houseCount = 0;
 export let farmlandCount = 0;
+export const FARMLAND_PER_VILLAGER = 2;
 
 const VILLAGER_EMOJIS = [
     '\u{1F3C3}\u{FE0F}\u{200D}\u{2642}\u{FE0F}',
@@ -232,7 +233,7 @@ export function stepVillager(v, index, ticks, log) {
         }
     }
 
-    const needed = farmlandCount < villagers.length;
+    const needed = farmlandCount < villagers.length * FARMLAND_PER_VILLAGER;
     if (!v.carrying && needed) {
         if (tile.type === 'grass') {
             tile.type = 'farmland';
@@ -276,7 +277,7 @@ export function stepVillager(v, index, ticks, log) {
             }
             v.status = status;
             return;
-        } else if (farmlandCount < villagers.length) {
+        } else if (farmlandCount < villagers.length * FARMLAND_PER_VILLAGER) {
             if (!v.target || v.task !== 'make_farmland' || tiles[v.target.y][v.target.x].type !== 'grass') {
                 v.target = findNearestGrass(v.x, v.y);
             }


### PR DESCRIPTION
## Summary
- increase farmland needs to 2 tiles per villager
- document new requirement in README

## Testing
- `node -e "import('./src/villager.js').then(()=>console.log('ok')).catch(e=>console.error(e))" --experimental-modules --no-warnings` *(fails: ReferenceError: window is not defined)*