### PR TITLE
Implement targeted gathering and spawn at houses

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,6 @@ Mini Colony Simulator is a lightweight browser game that depicts a small communi
 1. Open `index.html` in a modern web browser.
 2. Watch as the villagers move around and expand their colony.
 3. Use the **Pause** button to pause or resume the simulation.
-4. Use **Add Villager** to introduce a new villager manually.
+4. Use **Add Villager** to introduce a new villager manually at a random house.
 
 Keep this README up to date with any future changes to game behavior.

--- a/src/game.js
+++ b/src/game.js
@@ -1,5 +1,5 @@
 import { TILE_SIZE, GRID_WIDTH, GRID_HEIGHT, COLORS, EMOJIS, FOOD_EMOJIS, tiles, generateLandscape } from './tiles.js';
-import { villagers, addVillager, stepVillager, countHouses, countFarmland, getHousingCapacity, getTotalFood, generateHouseName, houseCount } from './villager.js';
+import { villagers, addVillager, stepVillager, countHouses, countFarmland, getHousingCapacity, getTotalFood, generateHouseName, houseCount, getRandomHousePos } from './villager.js';
 
 const canvas = document.getElementById('gameCanvas');
 const ctx = canvas.getContext('2d');
@@ -224,5 +224,10 @@ document.getElementById('toggleSim').addEventListener('click', () => {
 });
 
 document.getElementById('addVillager').addEventListener('click', () => {
-    addVillager(undefined, undefined, log);
+    const pos = getRandomHousePos();
+    if (pos) {
+        addVillager(pos.x, pos.y, log);
+    } else {
+        addVillager(undefined, undefined, log);
+    }
 });

--- a/src/tiles.js
+++ b/src/tiles.js
@@ -34,6 +34,7 @@ for (let y = 0; y < GRID_HEIGHT; y++) {
             type: 'grass',
             hasCrop: false,
             cropEmoji: null,
+            targeted: false,
             stored: 0,
             name: null,
             corpseEmoji: null,


### PR DESCRIPTION
## Summary
- spawn manually added villagers at a random house
- track when crop tiles are targeted so villagers don't share targets
- allow villagers to release targets when changing tasks
- add function to pick a random house
- document Add Villager change in README

## Testing
- `npm test` *(fails: package.json missing)*