### PR TITLE
Limit villagers preparing farmland once enough assigned

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ Mini Colony Simulator is a lightweight browser game that depicts a small communi
 
 - The world is procedurally generated with grass, water, forests, mountains and ore deposits using roaming walkers for more natural looking terrain. Grass and farmland tiles are drawn with darker colors. Forest tiles show a tree emoji.
 - Villagers create new farmland when stored food is low or there are fewer than two fields per villager. They will travel to the nearest grass tile and convert it into farmland. Farmland has a small chance each tick to regrow crops after being harvested. Grown crops show a random food emoji.
+- When multiple villagers are preparing new fields, the game counts how many grass tiles are already targeted so others continue their tasks once the need is met.
 - The game map scales to your browser, covering 95% of its width and 60% of its height when the world is generated.
 - The colony begins with a single house placed at a random location and the first villager starts on that house. Farmland must be created by villagers.
 - Villagers search for farmland with crops, harvest a single unit of food, then carry it back to the nearest house. Harvested farmland remains farmland.

--- a/src/villager.js
+++ b/src/villager.js
@@ -4,6 +4,7 @@ export const villagers = [];
 export let houseCount = 0;
 export let farmlandCount = 0;
 export const FARMLAND_PER_VILLAGER = 2;
+let farmlandTargetCount = 0;
 
 const VILLAGER_EMOJIS = [
     '\u{1F3C3}\u{FE0F}\u{200D}\u{2642}\u{FE0F}',
@@ -184,7 +185,10 @@ function moveTowards(v, target) {
 function releaseTarget(v) {
     if (v.target) {
         const t = tiles[v.target.y]?.[v.target.x];
-        if (t && t.targeted) t.targeted = false;
+        if (t && t.targeted) {
+            if (v.task === 'make_farmland') farmlandTargetCount--;
+            t.targeted = false;
+        }
     }
 }
 
@@ -288,7 +292,7 @@ export function stepVillager(v, index, ticks, log) {
         }
     }
 
-    const needed = farmlandCount < villagers.length * FARMLAND_PER_VILLAGER;
+    const needed = farmlandCount + farmlandTargetCount < villagers.length * FARMLAND_PER_VILLAGER;
     if (!v.carrying && needed) {
         if (tile.type === 'grass') {
             tile.type = 'farmland';
@@ -305,7 +309,10 @@ export function stepVillager(v, index, ticks, log) {
             if (!v.target || v.task !== 'make_farmland' || tiles[v.target.y][v.target.x].type !== 'grass') {
                 releaseTarget(v);
                 v.target = findNearestGrass(v.x, v.y);
-                if (v.target) tiles[v.target.y][v.target.x].targeted = true;
+                if (v.target) {
+                    tiles[v.target.y][v.target.x].targeted = true;
+                    farmlandTargetCount++;
+                }
             }
             if (v.target) {
                 moveTowards(v, v.target);
@@ -338,11 +345,14 @@ export function stepVillager(v, index, ticks, log) {
             }
             v.status = status;
             return;
-        } else if (farmlandCount < villagers.length * FARMLAND_PER_VILLAGER) {
+        } else if (farmlandCount + farmlandTargetCount < villagers.length * FARMLAND_PER_VILLAGER) {
             if (!v.target || v.task !== 'make_farmland' || tiles[v.target.y][v.target.x].type !== 'grass') {
                 releaseTarget(v);
                 v.target = findNearestGrass(v.x, v.y);
-                if (v.target) tiles[v.target.y][v.target.x].targeted = true;
+                if (v.target) {
+                    tiles[v.target.y][v.target.x].targeted = true;
+                    farmlandTargetCount++;
+                }
             }
             if (v.target) {
                 moveTowards(v, v.target);


### PR DESCRIPTION
## Summary
- track number of grass tiles targeted for conversion to farmland
- stop assigning more villagers to farmland once existing and targeted fields meet demand
- document farmland targeting behaviour in README

## Testing
- `node --check src/villager.js`
- `node --check src/game.js`