### PR TITLE
Fix farmland prep bug

### DIFF
--- a/src/villager.js
+++ b/src/villager.js
@@ -352,7 +352,10 @@ export function stepVillager(v, index, ticks, log) {
             tile.type = 'farmland';
             tile.hasCrop = false;
             tile.cropEmoji = null;
-            tile.targeted = false;
+            if (tile.targeted) {
+                tile.targeted = false;
+                farmlandTargetCount--;
+            }
             farmlandCount++;
             if (log) log(`${v.name} prepared farmland`);
             releaseTarget(v);


### PR DESCRIPTION
## Summary
- decrement farmland target count if targeted tile becomes farmland

## Testing
- `npm test` *(fails: package.json missing)*