### PR TITLE
Fix farmland counter updates

### DIFF
--- a/src/villager.js
+++ b/src/villager.js
@@ -361,6 +361,9 @@ export function stepVillager(v, index, ticks, log) {
                 farmlandTargetCount--;
             }
             farmlandCount++;
+            // keep farmlandCount in sync immediately after converting a tile
+            // so other villagers see the updated total on the same tick
+            countFarmland();
             if (log) log(`${v.name} prepared farmland`);
             releaseTarget(v);
             v.task = null;


### PR DESCRIPTION
## Summary
- keep farmland count accurate immediately after farmland creation

## Testing
- `npm test` *(fails: ENOENT)*