### PR TITLE
Improve villager house building logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,9 +12,9 @@ Mini Colony Simulator is a lightweight browser game that depicts a small communi
 - The colony begins with a single house placed at a random location and the first villager starts on that house. Farmland must be created by villagers.
 - Villagers search for farmland with crops, harvest a single unit of food, then carry it back to the nearest house. Harvested farmland remains farmland.
 - Villager movement now uses pathfinding to avoid water so they won't get stuck while walking to their destinations.
-- When villagers have no immediate task they now wait in place instead of wandering randomly.
+- Villagers always wait in place when they have no task and never wander randomly.
 - Houses store deposited food and wood. Each house provides housing for five villagers and is given a procedurally generated name.
-- When the population has reached the current housing capacity, villagers who have just eaten will chop trees if fewer than 10 wood are currently being gathered (including wood being carried or targeted). Once 10 wood is stored, a villager standing on a grass tile will build a new house.
+- When the population has reached the current housing capacity, villagers who have just eaten will chop trees if fewer than 10 wood are currently being gathered (including wood being carried or targeted). When at least 10 wood is stored and no other villager is preparing a house, the eater will head to the nearest field and build a new house there.
 - Houses with stored food periodically spend one food to spawn an additional villager if housing space is available. Villagers are represented by a variety of sports-themed emojis.
 - Villagers lose 1 health each tick and die if it reaches zero. They no longer die of old age. When their health falls below 90 they go to the nearest house to eat and regain full health. If no food is stored, they instead convert the nearest grass tile to farmland.
 - Hovering over any tile shows a tooltip listing everything on that space. The

--- a/src/tiles.js
+++ b/src/tiles.js
@@ -35,6 +35,7 @@ for (let y = 0; y < GRID_HEIGHT; y++) {
             hasCrop: false,
             cropEmoji: null,
             targeted: false,
+            houseTargeted: false,
             stored: 0,
             wood: 0,
             name: null,

--- a/src/villager.js
+++ b/src/villager.js
@@ -7,6 +7,7 @@ export let deathCount = 0;
 export const FARMLAND_PER_VILLAGER = 2;
 export const HOUSE_SPAWN_TIME = 200;
 let farmlandTargetCount = 0;
+let houseTargetCount = 0;
 
 export function getWoodBeingGathered() {
     let amount = getTotalWood();
@@ -164,6 +165,24 @@ function findNearestForest(x, y) {
     return best;
 }
 
+function findNearestFarmland(x, y) {
+    let best = null;
+    let bestDist = Infinity;
+    for (let yy = 0; yy < GRID_HEIGHT; yy++) {
+        for (let xx = 0; xx < GRID_WIDTH; xx++) {
+            const t = tiles[yy][xx];
+            if (t.type === 'farmland' && !t.houseTargeted) {
+                const d = Math.abs(x - xx) + Math.abs(y - yy);
+                if (d < bestDist) {
+                    bestDist = d;
+                    best = { x: xx, y: yy };
+                }
+            }
+        }
+    }
+    return best;
+}
+
 function findPathStep(sx, sy, tx, ty) {
     if (sx === tx && sy === ty) return null;
     const visited = Array.from({ length: GRID_HEIGHT }, () => Array(GRID_WIDTH).fill(false));
@@ -217,8 +236,14 @@ function releaseTarget(v) {
         if (t && t.targeted) {
             t.targeted = false;
         }
+        if (t && t.houseTargeted) {
+            t.houseTargeted = false;
+        }
         if (v.task === 'make_farmland' && farmlandTargetCount > 0) {
             farmlandTargetCount--;
+        }
+        if (v.task === 'build_house' && houseTargetCount > 0) {
+            houseTargetCount--;
         }
     }
 }
@@ -416,6 +441,18 @@ export function stepVillager(v, index, ticks, log) {
                         v.task = 'make_farmland';
                         status = 'seeking farmland site';
                     }
+                } else if (
+                    villagers.length >= getHousingCapacity() &&
+                    getTotalWood() >= 10 &&
+                    houseTargetCount === 0
+                ) {
+                    v.target = findNearestFarmland(v.x, v.y);
+                    if (v.target) {
+                        tiles[v.target.y][v.target.x].houseTargeted = true;
+                        houseTargetCount++;
+                        v.task = 'build_house';
+                        status = 'seeking house site';
+                    }
                 } else if (villagers.length >= getHousingCapacity() && getWoodBeingGathered() < 10) {
                     v.target = findNearestForest(v.x, v.y);
                     if (v.target) {
@@ -508,20 +545,34 @@ export function stepVillager(v, index, ticks, log) {
         } else {
             moveTowards(v, v.target);
         }
-    } else {
-        if (v.task === 'wait') {
+    } else if (v.task === 'build_house') {
+        status = 'building';
+        if (!v.target) {
             releaseTarget(v);
-            status = 'waiting';
-        } else {
-            releaseTarget(v);
-            const dir = Math.floor(Math.random() * 4);
-            if (dir === 0 && v.x > 0 && !isTileOccupied(v.x - 1, v.y)) v.x--;
-            if (dir === 1 && v.x < GRID_WIDTH - 1 && !isTileOccupied(v.x + 1, v.y)) v.x++;
-            if (dir === 2 && v.y > 0 && !isTileOccupied(v.x, v.y - 1)) v.y--;
-            if (dir === 3 && v.y < GRID_HEIGHT - 1 && !isTileOccupied(v.x, v.y + 1)) v.y++;
             v.task = null;
-            status = 'wandering';
+        } else if (v.x === v.target.x && v.y === v.target.y) {
+            const targetTile = tiles[v.y][v.x];
+            if (targetTile.type === 'farmland' && spendWood(10)) {
+                targetTile.type = 'house';
+                targetTile.hasCrop = false;
+                targetTile.stored = 0;
+                targetTile.wood = 0;
+                targetTile.name = generateHouseName();
+                targetTile.spawnTimer = HOUSE_SPAWN_TIME;
+                houseCount++;
+                if (log) log(`${v.name} built ${targetTile.name}`);
+            }
+            targetTile.houseTargeted = false;
+            if (houseTargetCount > 0) houseTargetCount--;
+            v.task = null;
+            v.target = null;
+        } else {
+            moveTowards(v, v.target);
         }
+    } else {
+        releaseTarget(v);
+        status = 'waiting';
+        v.task = 'wait';
     }
     v.status = status;
 }


### PR DESCRIPTION
## Summary
- add `houseTargeted` property for tiles
- track `houseTargetCount` and add `findNearestFarmland`
- send villagers to build a house on farmland after eating when wood is available
- remove wandering fallback so villagers always wait
- document the new behaviour in README

## Testing
- `node --check src/villager.js`
- `node --check src/game.js`