### PR TITLE
Improve villager house building logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,9 +12,9 @@ Mini Colony Simulator is a lightweight browser game that depicts a small communi
 - The colony begins with a single house placed at a random location and the first villager starts on that house. Farmland must be created by villagers.
 - Villagers search for farmland with crops, harvest a single unit of food, then carry it back to the nearest house. Harvested farmland remains farmland.
 - Villager movement now uses pathfinding to avoid water so they won't get stuck while walking to their destinations.
-- When villagers have no immediate task they now wait in place instead of wandering randomly.
+- Villagers always wait in place when they have no task and never wander randomly.
 - Houses store deposited food and wood. Each house provides housing for five villagers and is given a procedurally generated name.
-- When the population has reached the current housing capacity, villagers who have just eaten will chop trees if fewer than 10 wood are currently being gathered (including wood being carried or targeted). Once 10 wood is stored, a villager standing on a grass tile will build a new house.
+- When the population has reached the current housing capacity, villagers who have just eaten will chop trees if fewer than 10 wood are currently being gathered (including wood being carried or targeted). When at least 10 wood is stored and no other villager is preparing a house, the eater will head to the nearest grass tile and build a new house there.
 - Houses with stored food periodically spend one food to spawn an additional villager if housing space is available. Villagers are represented by a variety of sports-themed emojis.
 - Villagers lose 1 health each tick and die if it reaches zero. They no longer die of old age. When their health falls below 90 they go to the nearest house to eat and regain full health. If no food is stored, they instead convert the nearest grass tile to farmland.
 - Hovering over any tile shows a tooltip listing everything on that space. The

--- a/src/tiles.js
+++ b/src/tiles.js
@@ -35,6 +35,7 @@ for (let y = 0; y < GRID_HEIGHT; y++) {
             hasCrop: false,
             cropEmoji: null,
             targeted: false,
+            houseTargeted: false,
             stored: 0,
             wood: 0,
             name: null,


### PR DESCRIPTION
## Summary
- add `houseTargeted` property for tiles
- track `houseTargetCount` and add `findNearestGrassForHouse`
- send villagers to build a house on grass after eating when wood is available
- remove wandering fallback so villagers always wait
- document that house construction now starts on grass when wood is ready

## Testing
- `node --check src/villager.js`
- `node --check src/game.js`
