### PR TITLE
Fix farmland count update on farmland creation

### DIFF
--- a/src/villager.js
+++ b/src/villager.js
@@ -408,6 +408,7 @@ export function stepVillager(v, index, ticks, log) {
                 t.type = 'farmland';
                 t.hasCrop = false;
                 t.cropEmoji = null;
+                farmlandCount++;
             }
             t.targeted = false;
             v.target = null;


### PR DESCRIPTION
## Summary
- increment `farmlandCount` when a villager converts a tile to farmland

## Testing
- `git status --short`