### PR TITLE
Bug fix: enable fighting and show enemy tooltips

### DIFF
--- a/src/game.js
+++ b/src/game.js
@@ -231,6 +231,10 @@ function updateTooltip() {
                    `Health: ${Math.floor(v.health)}`,
                    `Status: ${v.status}`);
     }
+    const foes = enemies.filter(e => e.x === hoverX && e.y === hoverY);
+    for (const f of foes) {
+        lines.push(`Enemy ${f.emoji}`, `Health: ${Math.floor(f.health)}`);
+    }
     const content = lines.join('<br>');
     if (content) {
         tooltip.innerHTML = content;

--- a/src/villager.js
+++ b/src/villager.js
@@ -377,7 +377,7 @@ export function stepVillager(v, index, ticks, log) {
     let engaged = false;
     for (let i = enemies.length - 1; i >= 0; i--) {
         const e = enemies[i];
-        if (Math.abs(e.x - v.x) + Math.abs(e.y - v.y) === 1) {
+        if (Math.abs(e.x - v.x) + Math.abs(e.y - v.y) <= 1) {
             engaged = true;
             v.status = 'fighting';
             e.health -= 5;


### PR DESCRIPTION
## Summary
- show enemy information in tile tooltips
- treat overlapping enemies as engaged in combat

## Testing
- `git log -1 --stat`